### PR TITLE
Fixed memory leaks in human pose estimator

### DIFF
--- a/human-pose-estimator/src/human-pose-estimator-model.js
+++ b/human-pose-estimator/src/human-pose-estimator-model.js
@@ -68,6 +68,10 @@ const inference = function (imageTensor) {
     try {
       const results = run(imageTensor)
       return Promise.resolve(results)
+        .then((result) => {
+          tf.dispose(imageTensor)
+          return result
+        })
     } catch (err) {
       return Promise.reject(err)
     }

--- a/human-pose-estimator/test/test.js
+++ b/human-pose-estimator/test/test.js
@@ -1,4 +1,4 @@
-/* globals jasmine, describe, it, expect, tf */
+/* globals jasmine, describe, it, expect, beforeAll, tf */
 
 const jimp = require('jimp')
 const nodeCanvas = require('canvas')
@@ -21,6 +21,11 @@ describe('Human Pose Estimator', function () {
     .then(imageData => imageData.getBufferAsync(jimp.MIME_PNG))
     .then(imageBuffer => createCanvasElement(imageBuffer))
 
+  beforeAll(async function () {
+    // Load model before all tests so initial memory conditions are consistent
+    await poseEstimator.loadModel()
+  })
+
   it('version returns a valid version number', function () {
     expect(poseEstimator.version).toMatch(/(\d+\.){2}(\d+)/)
   })
@@ -30,13 +35,33 @@ describe('Human Pose Estimator', function () {
       .then(result => expect(result.shape).toContain(432))
   })
 
+  it('processInput() cleans up its tensors', function () {
+    let initialNumTensors = tf.memory().numTensors
+    // Should garbage collect every tensor except the one returned
+    return input.then(imageElement => poseEstimator.processInput(imageElement))
+      .then(() => expect(tf.memory().numTensors - initialNumTensors).toEqual(1))
+  })
+
   it('runInference() outputs correct dimensions (1, x, y, 57)', function () {
     return poseEstimator.runInference(tf.zeros([1, 512, 512, 3]))
       .then(result => expect(result.shape[3]).toEqual(57))
   })
 
-  it('predict() returns object with heatpMap, pafMap, posesDetected, and imageSize', function () {
+  it('runInference() cleans up its tensors', function () {
+    let initialNumTensors = tf.memory().numTensors
+    // Should garbage collect every tensor except the one returned
+    return poseEstimator.runInference(tf.zeros([1, 512, 512, 3]))
+      .then(() => expect(tf.memory().numTensors - initialNumTensors).toEqual(1))
+  })
+
+  it('predict() returns object with heatMap, pafMap, posesDetected, and imageSize', function () {
     return input.then(imageElement => poseEstimator.predict(imageElement))
       .then(result => expect(Object.keys(result)).toEqual(jasmine.arrayContaining(['heatMap', 'pafMap', 'posesDetected', 'imageSize'])))
+  })
+
+  it('has no memory leaks', function () {
+    let initialMemory = tf.memory()
+    return input.then(imageElement => poseEstimator.predict(imageElement))
+      .then(result => expect(initialMemory).toEqual(tf.memory()))
   })
 })


### PR DESCRIPTION
While testing the model I found that after each predict() there were 5 tensors that hadn't been garbage collected. This PR fixes this by deleting the inputTensors that are passed into functions once the computations for those tensors are completed.